### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/README
+++ b/README
@@ -60,7 +60,7 @@ https://github.com/Joelbyte/weak-bases.
 
 4. INSTALLATION AND RUNNING
 
-Weak Bases requires Logtalk 2.40.0 or a later version.
+Weak Bases requires Logtalk 3.36.0 or a later version.
 
 To use the latest version of Weak Bases, fetch the latest source
 code, either as an archive or from the git repository, extract it to

--- a/graphic.lgt
+++ b/graphic.lgt
@@ -1,9 +1,9 @@
 :- object(graphic).
 
 	:- info([
-		version is 1.0,
+		version is 1:0:0,
 		author is 'Victor Lagerkvist',
-		date is 2014/03/03,
+		date is 2014-03-03,
 		comment is 'Predicates for displaying graphics.'
 	]).
 

--- a/loader.lgt
+++ b/loader.lgt
@@ -2,7 +2,9 @@
 	% minimize compilation reports to the essential ones
 	set_logtalk_flag(report, warnings),
 	% load necessary library files
-	logtalk_load(library(meta_compiler_loader)),	
+	logtalk_load(types(loader)),
+	logtalk_load(sets(loader)),
+	logtalk_load(meta_compiler(loader)),
 	% load application files
 	logtalk_load([matrix, operators], [optimize(on)]),
 	logtalk_load(relations, [hook(meta_compiler), optimize(on)])

--- a/matrix.lgt
+++ b/matrix.lgt
@@ -1,9 +1,9 @@
 :- object(matrix).
 
 	:- info([
-		version is 1.0,
+		version is 1:0:0,
 		author is 'Victor Lagerkvist',
-		date is 2014/03/03,
+		date is 2014-03-03,
 		comment is 'A collection of matrix predicates.'
 	]).
 

--- a/operators.lgt
+++ b/operators.lgt
@@ -1,9 +1,9 @@
 :- object(operators).
 
 	:- info([
-		version is 1.0,
+		version is 1:0:0,
 		author is 'Victor Lagerkvist',
-		date is 2014/03/03,
+		date is 2014-03-03,
 		comment is 'Predicates working on operations.'
 	]).
 

--- a/relations.lgt
+++ b/relations.lgt
@@ -1,9 +1,9 @@
 :- object(relations).
 
 	:- info([
-		version is 1.0,
+		version is 1:0:0,
 		author is 'Victor Lagerkvist',
-		date is 2014/03/03,
+		date is 2014-03-03,
 		comment is 'Predicates working on relations.'
 	]).
 

--- a/tester.lgt
+++ b/tester.lgt
@@ -2,7 +2,9 @@
 	% minimize compilation reports to the essential ones
 	set_logtalk_flag(report, warnings),
 	% load necessary library files
-	logtalk_load(library(meta_compiler_loader)),	
+	logtalk_load(types(loader)),
+	logtalk_load(sets(loader)),
+	logtalk_load(meta_compiler(loader)),
 	% load the unit test tool
 	logtalk_load(lgtunit(loader)),
 	% load application files enabling support for code coverage

--- a/tests.lgt
+++ b/tests.lgt
@@ -2,9 +2,9 @@
 	extends(lgtunit)).
 
 	:- info([
-		version is 1.0,
+		version is 1:0:0,
 		author is 'Victor Lagerkvist',
-		date is 2014/06/12,
+		date is 2014-06-12,
 		comment is 'Unit tests for the "weak-bases" appliation.'
 	]).
 


### PR DESCRIPTION
Note that this pull requests makes Logtalk 3.36.0 or later required.